### PR TITLE
fix: replace ./. to speed up nix evaluation

### DIFF
--- a/package.nix
+++ b/package.nix
@@ -15,7 +15,7 @@ in stdenvNoCC.mkDerivation {
   name    = "crash";
   version = lib.head (lib.strings.match ''.*\.version = "([^"]*)".*'' (lib.readFile ./build.zig.zon));
 
-  src = ./.;
+  src = builtins.path { path = ./.; name = "source"; };
 
   dontCheck = true;
 


### PR DESCRIPTION
Currently, Nix (determinate 3.6.2) warns:

```
warning: Copying '«github:RGBCube/crash/7849872b30482ecab7d3586246e46855522ea64d»/' to the store again
You can make Nix evaluate faster and copy fewer files by replacing `./.` with the `self` flake input, or `builtins.path { path = ./.; name = "source"; }
```